### PR TITLE
Add ignore-and-log-errors instead ignore-errors and check for unbound slots in some places.

### DIFF
--- a/eazy-documentation.asd
+++ b/eazy-documentation.asd
@@ -18,6 +18,7 @@
               :common-doc
               :common-html
               :common-doc-split-paragraphs
+              :trivial-backtrace
               :cl-who)
  :pathname "src/"
  :serial t

--- a/src/0package.lisp
+++ b/src/0package.lisp
@@ -93,3 +93,16 @@ Advantages over the existing libraries:
       (apply #'format
              *error-output*
              format-string args))))
+
+
+(defun %ignore-and-log-errors (func)
+  (handler-bind ((error (lambda (c)
+                          (trivial-backtrace:print-backtrace c)
+                          (return-from %ignore-and-log-errors))))
+    (funcall func)))
+
+
+(defmacro ignore-and-log-errors (&body body)
+  `(%ignore-and-log-errors
+    (lambda ()
+      ,@body)))

--- a/src/1common.lisp
+++ b/src/1common.lisp
@@ -89,8 +89,9 @@ use uiop:pathname-directory-pathanme when you need path/to/dir/
 
 (defun copy-to-dir (src dir &optional force)
   (let ((dst (copy-destination src dir)))
-    (ignore-errors
-      (copy-file src dst :if-to-exists (if force :supersede :error)))))
+    (when (or (not (probe-file dst))
+              force)
+      (copy-file src dst :if-to-exists :supersede))))
 
 (defun local-enough-namestring (file)
   (enough-namestring file *local-root*))

--- a/src/2extractor.lisp
+++ b/src/2extractor.lisp
@@ -27,6 +27,17 @@
   (funcall *old-macroexpand-hook* expander form env))
 
 (defun extract-definitions (form)
+  ;; TODO: This code is for DEBUG only:
+  (let ((filename "doc/build/forms.lisp"))
+    (ensure-directories-exist filename)
+    (with-open-file (s filename
+                       :if-exists :append
+                       :if-does-not-exist :create
+                       :direction :output)
+      (write form :stream s)
+      (terpri s)
+      (terpri s)))
+  
   (match form
     #+(or)
     ((list* 'setf args)

--- a/src/2extractor.lisp
+++ b/src/2extractor.lisp
@@ -27,17 +27,6 @@
   (funcall *old-macroexpand-hook* expander form env))
 
 (defun extract-definitions (form)
-  ;; TODO: This code is for DEBUG only:
-  (let ((filename "doc/build/forms.lisp"))
-    (ensure-directories-exist filename)
-    (with-open-file (s filename
-                       :if-exists :append
-                       :if-does-not-exist :create
-                       :direction :output)
-      (write form :stream s)
-      (terpri s)
-      (terpri s)))
-  
   (match form
     #+(or)
     ((list* 'setf args)

--- a/src/3emitter.lisp
+++ b/src/3emitter.lisp
@@ -145,12 +145,12 @@
              (when (not (equal file pfile))
                (push
                 (make-section (make-content
-                               (list+ (ignore-errors
+                               (list+ (ignore-and-log-errors
                                         (make-text
                                          (or (pathname-name pfile)
                                              (error "skip"))
                                          :metadata (classes "file")))
-                                      (ignore-errors
+                                      (ignore-and-log-errors
                                         (make-text
                                          (or (pathname-type pfile)
                                              (error "skip"))
@@ -168,8 +168,10 @@
                (setf tmp-doc-entries nil))
              
              ;; make a new section across the directory boundary
-             (when (not (equal (ignore-errors (pathname-directory file))
-                               (ignore-errors (pathname-directory pfile))))
+             (when (not (equal (ignore-and-log-errors
+                                (pathname-directory file))
+                               (ignore-and-log-errors
+                                (pathname-directory pfile))))
                (push
                 (let ((dirname
                        (namestring
@@ -193,12 +195,12 @@
             tmp-doc-entries))
          (when tmp-doc-entries
            (push
-            (make-section (list+ (ignore-errors
+            (make-section (list+ (ignore-and-log-errors
                                    (make-text
                                     (or (pathname-name pfile)
                                         (error "skip"))
                                     :metadata (classes "file")))
-                                 (ignore-errors
+                                 (ignore-and-log-errors
                                    (make-text
                                     (or (pathname-type pfile)
                                         (error "skip"))
@@ -265,9 +267,10 @@
 (defun list+ (&rest args) (remove nil (flatten args)))
 
 (defun print-args (def)
-  (ignore-errors
+  (ignore-and-log-errors
     (span (let ((*print-pretty* t) (*print-right-margin* 1000))
-            (format nil "~(~{~a~^ ~}~)" (args def)))
+            (format nil "~(~{~a~^ ~}~)" (when (slot-boundp def 'args)
+                                          (args def))))
           "args" "lisp")))
 
 (defun print-package (def)
@@ -350,7 +353,9 @@
 (defun insert-docstring (def entry markup multi-p)
   (push (if (eq 'static-file (doctype def))
             (par (convert-file-to-html-string (file def)) "docstring")
-            (if-let ((doc (ignore-errors (docstring def))))
+            (if-let ((doc (ignore-and-log-errors
+                            (when (slot-boundp def 'docstring)
+                              (docstring def)))))
               (par (convert-string-to-html-string doc markup) "docstring")
               (par (if multi-p
                        "(all documentation missing)"

--- a/src/4user.lisp
+++ b/src/4user.lisp
@@ -133,7 +133,7 @@
     ;; Probably it is not a good idea to suppress all errors
     ;; Maybe we should at least use traceback as a document body?
     ;; This will make debugging simpler.
-    (ignore-errors
+    (ignore-and-log-errors
      (add-def :name (make-keyword (local-enough-namestring file))
               :doctype 'static-file
               :file file

--- a/src/4user.lisp
+++ b/src/4user.lisp
@@ -153,10 +153,14 @@
 
 (defun extract-definitions-from-system (system &key . #.+keywords+)
   #.+doc+
-  #.+ignore+  
+  #.+ignore+
+  ;; Ensure all dependencies to be compiled and loaded.
+  ;; Without this, all dependent libraries may be accidentally
+  ;; recompiled and may appear in the output.
   (let ((*compile-print* nil)
         (*compile-verbose* nil))
     (asdf:load-system system))
+  
   (uiop:with-temporary-file (:pathname p)
     (call-with-extracting-definitions
      (lambda ()


### PR DESCRIPTION
@guicho271828 Probably, we need to add `:initform nil` to the `defclass def`? This will make code simpler.

Are there any subtle moments in the code which rely on knowledge that some slots are unbound?

NOTE: This pull is into my fork, to make it easier to read. Because previous changes aren't merged to upstream yet: https://github.com/guicho271828/eazy-documentation/pull/2